### PR TITLE
Add setuptools to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pefile
 Pillow
+setuptools


### PR DESCRIPTION
I'm not a Python expert, so please feel free to deny this pull request or edit it as needed... if I'm not mistaken, icoextract also depends on setuptools. I tried v0.1.1 on openSUSE Leap 15.2 and it worked only after I installed the python3-setuptools package.