### PR TITLE
Add missing MIME type to thumbnailer

### DIFF
--- a/exe-thumbnailer.thumbnailer
+++ b/exe-thumbnailer.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 Exec=exe-thumbnailer -v -s %s %i %o
-MimeType=application/x-ms-dos-executable;application/x-dosexec;application/x-msdownload
+MimeType=application/x-ms-dos-executable;application/x-dosexec;application/x-msdownload;application/vnd.microsoft.portable-executable
 


### PR DESCRIPTION
I found some thumbnails were not generating because the MIME type "application/vnd.microsoft.portable-executable" was not included in the thumbnailer.